### PR TITLE
Throw exception when pdfinfo binary not found

### DIFF
--- a/src/Howtomakeaturn/PDFInfo/Exceptions/CommandNotFoundException.php
+++ b/src/Howtomakeaturn/PDFInfo/Exceptions/CommandNotFoundException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Howtomakeaturn\PDFInfo\Exceptions;
+
+use \Exception;
+
+class CommandNotFoundException extends Exception{};

--- a/src/Howtomakeaturn/PDFInfo/PDFInfo.php
+++ b/src/Howtomakeaturn/PDFInfo/PDFInfo.php
@@ -63,6 +63,8 @@ class PDFInfo
             throw new Exceptions\PDFPermissionException();
         } else if ( $returnVar === 99 ){
             throw new Exceptions\OtherException();
+        } else if ( $returnVar === 127 ){
+            throw new Exceptions\CommandNotFoundException();
         }
 
         $this->output = $output;


### PR DESCRIPTION
It can be important to catch when binary pdfinfo is not found by /bin/sh (return 127 code). Not found because not installed or not in PATH.