### PR TITLE
Prevent a deprecation warning in php >= 8.2

### DIFF
--- a/src/Howtomakeaturn/PDFInfo/PDFInfo.php
+++ b/src/Howtomakeaturn/PDFInfo/PDFInfo.php
@@ -25,6 +25,7 @@ class PDFInfo
     public $fileSize;
     public $optimized;
     public $PDFVersion;
+    public $pageRot;
 
     public static $bin;
 


### PR DESCRIPTION
This prevents a PHP deprecation notice "Creation of dynamic property Howtomakeaturn\PDFInfo\PDFInfo::$pageRot is deprecated"